### PR TITLE
Don't send $0 transactions to Taxamo

### DIFF
--- a/taxamo-edd-integration.php
+++ b/taxamo-edd-integration.php
@@ -383,6 +383,10 @@ if ( !class_exists( 'EDD_Taxamo_EDD_Integration' ) ) {
         public static function check_self_declaration( $valid_data, $data ) {
             global $edd_options;
 
+	    if ( edd_get_cart_subtotal() == 0 ) {
+                return;
+            }
+            
             if ( isset($data['edd_country'] ) ) {
 
                 if ( $data['billing_country'] != $data['edd_country'] ) {
@@ -532,6 +536,10 @@ if ( !class_exists( 'EDD_Taxamo_EDD_Integration' ) ) {
         public static function submit_order_to_taxamo( $payment_id ) {
             global $edd_options;
 
+	    if ( edd_get_payment_meta( $payment_id, '_edd_payment_total', true ) == 0 ) {
+                return;
+            }
+            
             if ( isset( $edd_options['taxedd_private_token'] ) ) {
 
                 $private_key = $edd_options['taxedd_private_token'];


### PR DESCRIPTION
When the transaction total is $0 (i.e. you are 'selling' a free product), EDD doesn't collect billing details. As far as I can tell, Taxamo also doesn't need to be notified about these transactions, since they're irrelevant for EU VAT purposes. So this fix simply avoids that.