### PR TITLE
Cache API calls to improve checkout page load speed

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -54,7 +54,7 @@ function taxedd_get_vat_details($vatnumber) {
 	if (isset( $edd_options['taxedd_private_token'] )) {
 
 		$private_key = $edd_options['taxedd_private_token'];
-		$taxresponse = wp_remote_get( 'https://api.taxamo.com/api/v1/tax/vat_numbers/'.$vatnumber.'/validate?private_token=' . $private_key );
+		$taxresponse = EDD_Taxamo_EDD_Integration_load()->get_api_response_vat_details( $vatnumber, $private_key );
 
 		if( ! is_wp_error( $taxresponse )
 			&& isset( $taxresponse['response']['code'] )        

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -26,7 +26,7 @@ function taxedd_get_country_code( $ip = "" ) {
 				$ip=$_SERVER['REMOTE_ADDR'];
 			}
 		}
-		$taxresponse = wp_remote_get( 'https://api.taxamo.com/api/v1/geoip/'.$ip.'?private_token='. $private_key );
+		$taxresponse = EDD_Taxamo_EDD_Integration_load()->get_api_response_geoip( $ip, $private_key );
 
 		if( ! is_wp_error( $taxresponse )
 			&& isset( $taxresponse['response']['code'] )        

--- a/taxamo-edd-integration.php
+++ b/taxamo-edd-integration.php
@@ -889,6 +889,21 @@ if ( !class_exists( 'EDD_Taxamo_EDD_Integration' ) ) {
         }
 
         /**
+         * Retrieve the results from the Taxamo api's VAT lookup
+         *
+         * @return array
+         */
+        function get_api_response_vat_details( $vatnumber, $private_key ) {
+
+            if ( $this->get_cached_api_response( 'vatnumber', $vatnumber ) ) {
+                return $this->get_cached_api_response( 'vatnumber', $vatnumber );
+            }
+
+            $this->api_responses['vatnumber'][ $vatnumber ] = wp_remote_get( 'https://api.taxamo.com/api/v1/tax/vat_numbers/'.$vatnumber.'/validate?private_token=' . $private_key );
+            return $this->api_responses['vatnumber'][ $vatnumber ];
+        }
+
+        /**
          * Retrieve a cached call to the Taxamo api if it exists
          *
          * @return array|bool

--- a/taxamo-edd-integration.php
+++ b/taxamo-edd-integration.php
@@ -872,6 +872,35 @@ if ( !class_exists( 'EDD_Taxamo_EDD_Integration' ) ) {
                 $resp = $refundtaxamo->createRefund( $transaction_key, $taxamo_body_array );
             }
         }
+
+        /**
+         * Retrieve the results from the Taxamo api's geoip lookup
+         *
+         * @return array
+         */
+        function get_api_response_geoip( $ip, $private_key ) {
+
+            if ( $this->get_cached_api_response( 'geoip', $ip ) ) {
+                return $this->get_cached_api_response( 'geoip', $ip );
+            }
+
+            $this->api_responses['geoip'][ $ip ] = wp_remote_get( 'https://api.taxamo.com/api/v1/geoip/'.$ip.'?private_token='. $private_key );
+            return $this->api_responses['geoip'][ $ip ];
+        }
+
+        /**
+         * Retrieve a cached call to the Taxamo api if it exists
+         *
+         * @return array|bool
+         */
+        function get_cached_api_response( $type, $id ) {
+
+            if ( empty( $this->api_responses ) || empty( $this->api_responses[ $type ] ) || empty( $this->api_responses[ $type ][ $id ] ) ) {
+                return false;
+            } else {
+                return $this->api_responses[ $type ][ $id ];
+            }
+        }
     }
 
 


### PR DESCRIPTION
This PR stores the results of the API calls in `/includes/functions.php` to prevent multiple calls in a single page load with the same data. It's not a persistent cache, just storing it into `EDD_Taxamo_EDD_Integration::api_responses` for retrieval.

The geoip lookup was the one that was really causing the delays. I went ahead and cached the vat details lookup as well, but I wasn't able to test that (I don't collect VAT details and Taxamo's API insists my VAT number is invalid -- though it validated the number in my account???).

Anyway, I recommend you test it before approving the PR.