### PR TITLE
Correctly pass APIClient as argument to Taxamo class instantiator.

### DIFF
--- a/taxamo-edd-integration.php
+++ b/taxamo-edd-integration.php
@@ -1163,13 +1163,13 @@ return array_merge( $settings, $new_settings );
                         "line_key" => $line_key );
                     $taxamo_body_json = json_encode( $taxamo_body_array );
 
-                // Create Taxamo Object and Submit a refund
+                    // Create Taxamo Object and Submit a refund
                     $private_key = $edd_options['taxedd_private_token'];
 
                     $apiclient = new APIClient( $private_key, 'https://api.taxamo.com' );
                     $apiclient->sourceId = '['.EDD_TAXAMOEDDINTEGRATION_DOMAIN.'-'.EDD_TAXAMOEDDINTEGRATION_NAME.'-'. EDD_TAXAMOEDDINTEGRATION_VER.']';
                     
-                    $refundtaxamo = new Taxamo( $private_key );
+                    $refundtaxamo = new Taxamo( $apiclient );
                     $resp = $refundtaxamo->createRefund( $transaction_key, $taxamo_body_array );
                 }
             }


### PR DESCRIPTION
This resolves a fatal error that happens when refunding a payment: 

```
PHP Fatal error:  Uncaught Error: Call to a member function toPathValue() on string in /path/to/wp/wp-content/plugins/easy-digital-downloads-taxamo-integration/includes/libraries/taxamo-api/Taxamo.php:54
```